### PR TITLE
without this, 'make install' doesn't work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ dep:
 	go get github.com/gorilla/mux
 	go get golang.org/x/tools/cmd/cover
 	go get github.com/mattn/goveralls
+	go get github.com/jens18/lgresu/datarecorder
 
 doc: doc/LGResuMon.pdf doc/RPISetup.pdf
 


### PR DESCRIPTION
make install
go get github.com/sirupsen/logrus
go get github.com/brutella/can
go get github.com/google/go-cmp/cmp
go get github.com/gorilla/mux
go get golang.org/x/tools/cmd/cover
go get github.com/mattn/goveralls
( cd cmd/lgresu_mon/; go build -ldflags="-X main.version=1.3-2-g1d330b5" lgresu_mon.go lgresu_actors.go )
lgresu_mon.go:24:2: cannot find package "github.com/jens18/lgresu/datarecorder" in any of:
	/usr/lib/go-1.10/src/github.com/jens18/lgresu/datarecorder (from $GOROOT)
	/home/buzz/go/src/github.com/jens18/lgresu/datarecorder (from $GOPATH)
lgresu_mon.go:25:2: cannot find package "github.com/jens18/lgresu/lgresustatus" in any of:
	/usr/lib/go-1.10/src/github.com/jens18/lgresu/lgresustatus (from $GOROOT)
	/home/buzz/go/src/github.com/jens18/lgresu/lgresustatus (from $GOPATH)
Makefile:16: recipe for target 'cmd/lgresu_mon/lgresu_mon' failed
make: *** [cmd/lgresu_mon/lgresu_mon] Error 1